### PR TITLE
Document available pages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ Welcome! This is a super straightforward admin dashboard template built with Tai
 
 Most existing templates try to be everything to everyone, which can make them hard to work with for small projects or quick prototypes. This template keeps things simple so you can focus on building your dashboard, not wrangling with unnecessary features.
 
+## Pages
+
+- **`home.html` – Marketing site**: A public-facing landing page for the European Islamic Forum Netherlands with a hero banner, organization overview, program highlights, upcoming events, testimonials, and contact/CTA blocks.
+- **`index.html` – Dashboard overview**: The primary admin view with a responsive sidebar, top search bar, dark-mode toggle, quick metric cards, a full-width KPI card, and a recent-orders table.
+- **`products.html` – Product catalog**: Displays a responsive grid of product cards so you can scan merchandise at a glance while keeping the same dashboard chrome (sidebar, search, dark mode).
+- **`single-product.html` – Product details**: Shows a rich product presentation page with breadcrumb navigation, gallery placeholders, pricing, stock and review badges, option selectors, marketing highlights, and collapsible info panels.
+- **`add-product.html` – Product creation form**: A multi-section form for entering product information, inventory, descriptions, and SEO metadata, plus a sticky action bar for saving or cancelling.
+- **`calendar.html` – Schedule management**: Integrates FullCalendar to present a monthly view of upcoming events with adaptive color coding and handles resizing/dark-mode updates.
+- **`cart.html` – Shopping cart**: Lists cart items with quantity steppers, remove actions, and a live order summary that recalculates subtotal, shipping, tax, and total amounts.
+- **`checkout.html` – Checkout flow**: Provides structured sections for contact info, shipping address, delivery method, payment, and review, alongside an order summary sidebar.
+- **`order-success.html` – Confirmation state**: Displays a thank-you message, order metadata, fulfillment timeline, and helpful next steps after checkout completes.
+- **`login.html` – Authentication (sign in)**: Presents a compact login form with username/password fields and built-in dark-mode toggle.
+- **`registration.html` – Authentication (sign up)**: Mirrors the login layout with fields for account creation, including email and password confirmation, plus dark-mode support.
+
 ## Getting Started
 
 1. Clone this repo


### PR DESCRIPTION
## Summary
- add a dedicated pages section to the README to outline every available screen in the template
- describe the purpose and major elements of each admin, storefront, and auth page so newcomers understand the layout
